### PR TITLE
Add device-tco-calculator to opt-out list

### DIFF
--- a/allstar.yaml
+++ b/allstar.yaml
@@ -1,3 +1,5 @@
 optConfig:
   disableRepoOverride: true
   optOutStrategy: true
+  optOutRepos:
+  - device-tco-calculator

--- a/allstar.yaml
+++ b/allstar.yaml
@@ -1,5 +1,3 @@
 optConfig:
   disableRepoOverride: true
   optOutStrategy: true
-  optOutRepos:
-    - device-tco-calculator

--- a/allstar.yaml
+++ b/allstar.yaml
@@ -2,4 +2,4 @@ optConfig:
   disableRepoOverride: true
   optOutStrategy: true
   optOutRepos:
-  - device-tco-calculator
+    - device-tco-calculator

--- a/branch_protection.yaml
+++ b/branch_protection.yaml
@@ -2,4 +2,6 @@ optConfig:
   optOutStrategy: true
   # TODO: Review policy
   optOutPrivateRepos: true
+  optOutRepos:
+    - device-tco-calculator
 action: issue


### PR DESCRIPTION
## Description

As discussed, we are opting-out [device-tco-calculator](https://github.com/cisco-open/device-tco-calculator) from the org-wide Allstar policy. 

Since we have the `disableRepoOverride` flag enabled, the [supported way](https://github.com/ossf/allstar/blob/main/opt-out.md#disable-allstar-org-level-opt-out-strategy) to achieve this is by explicitly naming the repository in a list of `optOutRepos`. 